### PR TITLE
Implement download to local cache and recover (Fixes #21 and #22)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,7 @@
 [submodule "submodules/fastlog"]
     path = submodules/fastlog
     url = https://github.com/Elemento-Modular-Cloud/elemento-fastlog.git
+
+[submodule "submodules/warpdrive"]
+    path = submodules/warpdrive
+    url = https://github.com/Elemento-Modular-Cloud/elemento-warpdrive.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(rucio-fuse-posix CXX)
 
 set (CMAKE_BUILD_TYPE DEBUG)
-set (CMAKE_CXX_STANDARD 11)
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 set (CMAKE_C_FLAGS "-O0 -ggdb")
 set (CMAKE_C_FLAGS_DEBUG "-O0 -ggdb")
 set (CMAKE_C_FLAGS_RELEASE "-O0 -ggdb")
@@ -29,7 +29,14 @@ find_package(CURL REQUIRED)
 include_directories(${CURL_INCLUDE_DIR})
 
 add_subdirectory(submodules)
-include_directories(include source submodules/SHA1 submodules/nlohmann_json/single_include/nlohmann)
+include_directories(include
+                    source
+                    submodules/SHA1
+                    submodules/nlohmann_json/single_include/nlohmann
+                    submodules/fastlog
+                    submodules/warpdrive/include/interfaces
+                    submodules/warpdrive/include
+                    )
 
 add_library(globals
         include/globals.h
@@ -45,7 +52,7 @@ add_library(utils
 add_library(curl-wrapper
         include/curl-REST.h
         source/curl-REST.cpp
-        )
+        include/rucio-download.h include/download-cache.h)
 target_link_libraries(curl-wrapper utils fastlog ${CURL_LIBRARIES})
 
 
@@ -58,12 +65,12 @@ target_link_libraries(rucio-rest-api-wrapper curl-wrapper utils globals fastlog)
 add_library(rucio-fuse
         include/fuse-op.h
         source/fuse-op.cpp
+        include/download-pipeline.h
         )
-target_link_libraries(rucio-fuse utils rucio-rest-api-wrapper fastlog ${FUSE_LIBRARIES})
+target_link_libraries(rucio-fuse utils rucio-rest-api-wrapper fastlog warpdrive ${FUSE_LIBRARIES})
 
 add_executable(rucio-fuse-main
-        main.cxx
-        )
+        main.cxx)
 target_link_libraries(rucio-fuse-main rucio-fuse globals)
 
 add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(rucio-fuse-posix CXX)
 
 set (CMAKE_BUILD_TYPE DEBUG)
 set (CMAKE_CXX_STANDARD 17)
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread")
 set (CMAKE_C_FLAGS "-O0 -ggdb")
 set (CMAKE_C_FLAGS_DEBUG "-O0 -ggdb")
 set (CMAKE_C_FLAGS_RELEASE "-O0 -ggdb")

--- a/include/download-cache.h
+++ b/include/download-cache.h
@@ -1,0 +1,41 @@
+//
+// Created by Gabriele Gaetano Fronzé on 2020-06-03.
+//
+
+#ifndef RUCIO_FUSE_POSIX_DOWNLOAD_CACHE_H
+#define RUCIO_FUSE_POSIX_DOWNLOAD_CACHE_H
+
+struct file_cache {
+    std::unordered_map<std::string, FILE*> cache;
+
+    file_cache(){
+      //TODO: here we can populate the cache at startup parsing all files in the cache root.
+    }
+
+    ~file_cache(){
+      for(auto &file : cache){
+        fclose(file.second);
+      }
+    }
+
+    bool is_cached(const std::string& key){
+      return cache.find(key) != cache.end();
+    }
+
+    FILE* get_file(const std::string& key){
+      return (is_cached(key))?cache[key]:nullptr;
+    }
+
+    bool add_file(const std::string& key, FILE* file){
+      cache[key] = file;
+      return true;
+    }
+
+    bool add_file(std::string key){
+      cache[key] = fopen(key.data(), "rb");
+      return true;
+    }
+};
+file_cache rucio_download_cache;
+
+#endif //RUCIO_FUSE_POSIX_DOWNLOAD_CACHE_H

--- a/include/download-cache.h
+++ b/include/download-cache.h
@@ -5,6 +5,8 @@
 #ifndef RUCIO_FUSE_POSIX_DOWNLOAD_CACHE_H
 #define RUCIO_FUSE_POSIX_DOWNLOAD_CACHE_H
 
+#include <unordered_map>
+
 struct file_cache {
     std::unordered_map<std::string, FILE*> cache;
 

--- a/include/download-pipeline.h
+++ b/include/download-pipeline.h
@@ -1,0 +1,94 @@
+//
+// Created by Gabriele Gaetano Fronzé on 2020-06-03.
+//
+
+#ifndef RUCIO_FUSE_POSIX_DOWNLOAD_PIPELINE_H
+#define RUCIO_FUSE_POSIX_DOWNLOAD_PIPELINE_H
+
+#include <ELWD_Pipeline.h>
+#include <ELWD_Starting_Stage_I.h>
+#include <ELWD_Middle_Stage_I.h>
+#include <ELWD_Ending_Stage_I.h>
+#include <ELWD_Safe_Queue.h>
+#include <ELWD_Load_Balanced_Thread_Pool.h>
+
+#include "rucio-download.h"
+
+// This thread picks from the input queue the information of rucio files to be downloaded and calls the wrapper.
+// It also implements multiple trials by routing the requests back to the input queue if maximum trials are reached.
+struct rucio_downloader : public ELWD_Middle_Stage_I<rucio_download_info, rucio_download_info, DummyT>{
+    rucio_downloader(ELWD_Safe_Queue<rucio_download_info>* inputQueue,
+                     ELWD_Safe_Queue<rucio_download_info>* outputQueue) :
+                     ELWD_Middle_Stage_I(0,inputQueue,outputQueue){}
+
+    rucio_download_info* get_input() final{
+      return new rucio_download_info(fInputQ->poll_and_pinch());
+    }
+
+    rucio_download_info* process_input(rucio_download_info* input) final{
+      fastlog(DEBUG, "Downloading did %s in %s.", input->fdid, input->ftmp_path);
+      return rucio_download_wrapper(*input);
+    }
+
+    void handle_output(rucio_download_info* output) final{
+      if (output->fdownloaded){
+        fastlog(DEBUG, "Did %s downloaded in %s!", output->fdid, output->fcache_path);
+        fOutputQ->append(*output);
+      } else {
+        fastlog(ERROR, "Did %s download failed!", output->fdid);
+        if(output->freturn_code != MAX_ATTEMPTS){
+          fastlog(INFO,"Trying again did %s download in %s.", output->fdid, output->fcache_path);
+          fInputQ->append(*output);
+        } else {
+          fastlog(ERROR, "Did %s maximum download attempts reached. Aborting!", output->fdid);
+          fOutputQ->append(*output);
+        }
+      }
+    }
+};
+
+// This thread picks from the input queue and does nothing but writing to the terminal!
+struct rucio_notifier : public ELWD_Ending_Stage_I<rucio_download_info, DummyT>{
+    rucio_notifier(ELWD_Safe_Queue<rucio_download_info>* queue) : ELWD_Ending_Stage_I(0,queue){}
+
+    rucio_download_info* get_input() final{
+      return new rucio_download_info(fInputQ->poll_and_pinch());
+    }
+
+    DummyT* process_input(rucio_download_info* input) final{
+      fastlog((input->fdownloaded)?INFO:ERROR, "%s", input->print());
+      //TODO: notify to the GUI the download status...
+      return nullptr;
+    }
+};
+
+struct rucio_pipeline{
+    ELWD_Safe_Queue<rucio_download_info> toDownload;
+    ELWD_Safe_Queue<rucio_download_info> downloaded;
+
+    ELWD_Thread_I* rucio_downloaders;
+    ELWD_Thread_I* rucio_notifiers;
+
+    ELWD_Pipeline pipeline;
+
+    rucio_pipeline(){
+      rucio_downloaders = new ELWD_Load_Balanced_Thread_Pool(rucio_downloader(&toDownload, &downloaded), 1);
+      rucio_notifiers = new ELWD_Load_Balanced_Thread_Pool(rucio_notifier(&downloaded), 1);
+
+      pipeline | rucio_downloaders | rucio_notifiers;
+
+      pipeline.start();
+    }
+
+    ~rucio_pipeline(){
+      pipeline.stop();
+    }
+
+    void append_new_download(rucio_download_info info){
+      toDownload.append(std::move(info));
+    }
+};
+
+static rucio_pipeline rucio_download_pipeline;
+
+#endif //RUCIO_FUSE_POSIX_DOWNLOAD_PIPELINE_H

--- a/include/download-pipeline.h
+++ b/include/download-pipeline.h
@@ -72,8 +72,8 @@ struct rucio_pipeline{
     ELWD_Pipeline pipeline;
 
     rucio_pipeline(){
-      rucio_downloaders = new ELWD_Load_Balanced_Thread_Pool(rucio_downloader(&toDownload, &downloaded), 1);
-      rucio_notifiers = new ELWD_Load_Balanced_Thread_Pool(rucio_notifier(&downloaded), 1);
+      rucio_downloaders = new ELWD_Load_Balanced_Thread_Pool<typeof(rucio_downloader)>(rucio_downloader(&toDownload, &downloaded), 1);
+      rucio_notifiers = new ELWD_Load_Balanced_Thread_Pool<typeof(rucio_notifier)>(rucio_notifier(&downloaded), 1);
 
       pipeline | rucio_downloaders | rucio_notifiers;
 

--- a/include/download-pipeline.h
+++ b/include/download-pipeline.h
@@ -26,18 +26,18 @@ struct rucio_downloader : public ELWD_Middle_Stage_I<rucio_download_info, rucio_
     }
 
     rucio_download_info* process_input(rucio_download_info* input) final{
-      fastlog(DEBUG, "Downloading did %s in %s.", input->fdid.data(), input->full_path().data());
+      fastlog(DEBUG, "Downloading did %s in %s.", input->fdid.data(), input->full_cache_path().data());
       return rucio_download_wrapper(*input);
     }
 
     void handle_output(rucio_download_info* output) final{
       if (output->fdownloaded){
-        fastlog(DEBUG, "Did %s downloaded in %s!", output->fdid.data(), output->full_path().data());
+        fastlog(DEBUG, "Did %s downloaded in %s!", output->fdid.data(), output->full_cache_path().data());
         fOutputQ->append(*output);
       } else {
         fastlog(ERROR, "Did %s download failed!", output->fdid.data());
         if(output->freturn_code != MAX_ATTEMPTS){
-          fastlog(INFO,"Trying again did %s download in %s.", output->fdid.data(), output->full_path().data());
+          fastlog(INFO,"Trying again did %s download in %s.", output->fdid.data(), output->full_cache_path().data());
           fInputQ->append(*output);
         } else {
           fastlog(ERROR, "Did %s maximum download attempts reached. Aborting!", output->fdid.data());

--- a/include/download-pipeline.h
+++ b/include/download-pipeline.h
@@ -26,18 +26,18 @@ struct rucio_downloader : public ELWD_Middle_Stage_I<rucio_download_info, rucio_
     }
 
     rucio_download_info* process_input(rucio_download_info* input) final{
-      fastlog(DEBUG, "Downloading did %s in %s.", input->fdid.data(), input->ftmp_path.data());
+      fastlog(DEBUG, "Downloading did %s in %s.", input->fdid.data(), input->full_path().data());
       return rucio_download_wrapper(*input);
     }
 
     void handle_output(rucio_download_info* output) final{
       if (output->fdownloaded){
-        fastlog(DEBUG, "Did %s downloaded in %s!", output->fdid.data(), output->fcache_path.data());
+        fastlog(DEBUG, "Did %s downloaded in %s!", output->fdid.data(), output->full_path().data());
         fOutputQ->append(*output);
       } else {
         fastlog(ERROR, "Did %s download failed!", output->fdid.data());
         if(output->freturn_code != MAX_ATTEMPTS){
-          fastlog(INFO,"Trying again did %s download in %s.", output->fdid.data(), output->fcache_path.data());
+          fastlog(INFO,"Trying again did %s download in %s.", output->fdid.data(), output->full_path().data());
           fInputQ->append(*output);
         } else {
           fastlog(ERROR, "Did %s maximum download attempts reached. Aborting!", output->fdid.data());

--- a/include/fuse-op.h
+++ b/include/fuse-op.h
@@ -5,8 +5,8 @@ Authors:
 - Vivek Nigam <viveknigam.nigam3@gmail.com>, 2020
 */
 
-#ifndef RUCIO_FUSE_FUSE_OP_H
-#define RUCIO_FUSE_FUSE_OP_H
+#ifndef RUCIO_FUSE_POSIX_OP_H
+#define RUCIO_FUSE_POSIX_OP_H
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -239,4 +239,4 @@ static int rucio_read(const char *path, char *buffer, size_t size, off_t offset,
   return -1;
 }
 
-#endif //RUCIO_FUSE_FUSE_OP_H
+#endif //RUCIO_FUSE_POSIX_OP_H

--- a/include/fuse-op.h
+++ b/include/fuse-op.h
@@ -22,6 +22,7 @@ Authors:
 #include "constants.h"
 #include "download-cache.h"
 #include "rucio-download.h"
+#include "download-pipeline.h"
 
 using namespace fastlog;
 
@@ -161,11 +162,10 @@ static int rucio_read(const char *path, char *buffer, size_t size, off_t offset,
     if(not rucio_download_cache.is_cached(cache_path)) {
       fastlog(DEBUG,"File %s @ %s is not cached. Downloading...", did.data(), server_name.data());
 
-      auto return_code = rucio_download_wrapper(tmp_path, cache_path, did);
+//      auto return_code = rucio_download_wrapper(tmp_path, cache_path, did);
+      rucio_download_pipeline.append_new_download(rucio_download_info(cache_path, did));
 
-      if (return_code == FILE_NOT_FOUND){
-        return -ENOENT;
-      }
+      return -ENOENT;
     } else {
       fastlog(DEBUG,"File %s @ %s found in cache!", did.data(), server_name.data());
     }

--- a/include/fuse-op.h
+++ b/include/fuse-op.h
@@ -161,7 +161,6 @@ static int rucio_read(const char *path, char *buffer, size_t size, off_t offset,
     if(not rucio_download_cache.is_cached(cache_path)) {
       fastlog(DEBUG,"File %s @ %s is not cached. Downloading...", did.data(), server_name.data());
 
-//      auto return_code = rucio_download_wrapper(did);
       rucio_download_pipeline.append_new_download(rucio_download_info(did));
 
       return -ENOENT;

--- a/include/fuse-op.h
+++ b/include/fuse-op.h
@@ -161,7 +161,7 @@ static int rucio_read(const char *path, char *buffer, size_t size, off_t offset,
     if(not rucio_download_cache.is_cached(cache_path)) {
       fastlog(DEBUG,"File %s @ %s is not cached. Downloading...", did.data(), server_name.data());
 
-//      auto return_code = rucio_download_wrapper(tmp_path, cache_path, did);
+//      auto return_code = rucio_download_wrapper(did);
       rucio_download_pipeline.append_new_download(rucio_download_info(did));
 
       return -ENOENT;

--- a/include/fuse-op.h
+++ b/include/fuse-op.h
@@ -157,13 +157,12 @@ static int rucio_read(const char *path, char *buffer, size_t size, off_t offset,
     auto did = get_did(path);
     std::string cache_root = rucio_cache_path + "/" + server_name;
     std::string cache_path = cache_root + "/" + did;
-    std::string tmp_path = cache_path + ".download";
 
     if(not rucio_download_cache.is_cached(cache_path)) {
       fastlog(DEBUG,"File %s @ %s is not cached. Downloading...", did.data(), server_name.data());
 
 //      auto return_code = rucio_download_wrapper(tmp_path, cache_path, did);
-      rucio_download_pipeline.append_new_download(rucio_download_info(cache_path, did));
+      rucio_download_pipeline.append_new_download(rucio_download_info(did));
 
       return -ENOENT;
     } else {

--- a/include/fuse-op.h
+++ b/include/fuse-op.h
@@ -164,6 +164,11 @@ struct file_cache {
       return (is_cached(key))?cache[key]:nullptr;
     }
 
+    bool add_file(std::string key, FILE* file){
+      cache[key] = file;
+      return true;
+    }
+
     bool add_file(std::string key){
       cache[key] = fopen(key.data(), "rb");
       return true;
@@ -182,6 +187,8 @@ static int rucio_read(const char *path, char *buffer, size_t size, off_t offset,
     std::string cache_root = rucio_cache_path + "/" + server_name;
     std::string cache_path = cache_root + "/" + did;
 
+    FILE* file = nullptr;
+
     if(not rucio_download_cache.is_cached(cache_path)) {
       //TODO: using rucio download directly, prevents from being able to connect to multiple rucio servers at once
 
@@ -189,14 +196,22 @@ static int rucio_read(const char *path, char *buffer, size_t size, off_t offset,
       std::string command = "rucio download --dir " + cache_root + " " + did;
       system(command.data());
 
+      fastlog(DEBUG,"Checking downloaded file...");
+      file = fopen(cache_path.data(), "rb");
+
+      if(not file){
+        fastlog(ERROR, "Failed file download! Passing over...");
+        return -ENOENT;
+      }
+
       fastlog(DEBUG,"File downloaded at %s and added to cache.", cache_path.data());
-      rucio_download_cache.add_file(cache_path);
+      rucio_download_cache.add_file(cache_path, file);
     } else {
       fastlog(DEBUG,"File %s @ %s found in cache!", did.data(), server_name.data());
     }
 
     fastlog(DEBUG,"Getting file...");
-    auto file = rucio_download_cache.get_file(cache_path);
+    file = rucio_download_cache.get_file(cache_path);
 
     fastlog(DEBUG,"Seeking file...");
     fseek(file, offset, SEEK_SET);

--- a/include/rucio-download.h
+++ b/include/rucio-download.h
@@ -7,6 +7,7 @@
 
 #include <fastlog.h>
 #include "download-cache.h"
+#include "constants.h"
 
 using namespace fastlog;
 
@@ -44,12 +45,12 @@ struct rucio_download_info{
     std::string fdid;
     std::string::size_type fpos;
     int freturn_code = 0;
-    uint fattempt = 0;
+    unsigned int fattempt = 0;
     bool fdownloaded = false;
 
     explicit rucio_download_info(std::string did) :
       fdid(std::move(did)){
-      fpos = did.find_first_of(':');
+      fpos = fdid.find_first_of(':');
     }
 
     std::string print(){
@@ -65,7 +66,7 @@ struct rucio_download_info{
     }
 
     std::string filename(){
-      return fdid.substr(fpos, fdid.size());
+      return fdid.substr(fpos+1);
     }
 
     std::string full_path(){

--- a/include/rucio-download.h
+++ b/include/rucio-download.h
@@ -23,8 +23,8 @@ int rucio_download_wrapper(const std::string& did, const std::string& scope){
   FILE* file = fopen(file_path.data(), "rb");
 
   if (file){
-    fclose(file);
     fastlog(INFO,"File %s already there!",file_path.data());
+    rucio_download_cache.add_file(file_path, file);
     return 0;
   }
 

--- a/include/rucio-download.h
+++ b/include/rucio-download.h
@@ -17,7 +17,7 @@ using namespace fastlog;
 int rucio_download_wrapper(const std::string& tmp_path, const std::string& cache_path, const std::string& did){
   //TODO: using rucio download directly, prevents from being able to connect to multiple rucio servers at once
 
-  std::string command = "rucio download --dir " + tmp_path + " " + did;
+  std::string command = "rucio download --verbose --dir " + tmp_path + " " + did;
   system(command.data());
 
   fastlog(DEBUG,"Checking downloaded file...");

--- a/include/rucio-download.h
+++ b/include/rucio-download.h
@@ -17,7 +17,7 @@ using namespace fastlog;
 int rucio_download_wrapper(const std::string& tmp_path, const std::string& cache_path, const std::string& did){
   //TODO: using rucio download directly, prevents from being able to connect to multiple rucio servers at once
 
-  std::string command = "rucio download --verbose --dir " + tmp_path + " " + did;
+  std::string command = "rucio --verbose download --dir " + tmp_path + " " + did;
   system(command.data());
 
   fastlog(DEBUG,"Checking downloaded file...");

--- a/include/rucio-download.h
+++ b/include/rucio-download.h
@@ -26,7 +26,8 @@ int rucio_download_wrapper(const std::string& did, const std::string& scope){
   system(command.data());
 
   fastlog(DEBUG,"Checking downloaded file...");
-  FILE* file = fopen(cache_path.data(), "rb");
+  auto file_path = cache_path + "/" + did;
+  FILE* file = fopen(file_path.data(), "rb");
 
   if(not file){
     fastlog(ERROR, "Failed file download! Passing over...");
@@ -35,8 +36,8 @@ int rucio_download_wrapper(const std::string& did, const std::string& scope){
     fastlog(DEBUG, "Download OK! Renaming temporary file...");
   }
 
-  fastlog(DEBUG,"Adding to cache file downloaded at %s.", cache_path.data());
-  rucio_download_cache.add_file(cache_path, file);
+  fastlog(DEBUG,"Adding to cache file downloaded at %s.", file_path.data());
+  rucio_download_cache.add_file(file_path, file);
 
   return 0;
 }

--- a/include/rucio-download.h
+++ b/include/rucio-download.h
@@ -1,0 +1,72 @@
+//
+// Created by Gabriele Gaetano Fronzé on 2020-06-03.
+//
+
+#ifndef RUCIO_FUSE_POSIX_RUCIO_DOWNLOAD_H
+#define RUCIO_FUSE_POSIX_RUCIO_DOWNLOAD_H
+
+#include <fastlog.h>
+#include "download-cache.h"
+
+using namespace fastlog;
+
+#define FILE_NOT_FOUND 42
+#define MAX_ATTEMPTS 3
+#define TOO_MANY_ATTEMPTS 314
+
+int rucio_download_wrapper(const std::string& tmp_path, const std::string& cache_path, const std::string& did){
+  //TODO: using rucio download directly, prevents from being able to connect to multiple rucio servers at once
+
+  std::string command = "rucio download --dir " + tmp_path + " " + did;
+  system(command.data());
+
+  fastlog(DEBUG,"Checking downloaded file...");
+  FILE* file = fopen(tmp_path.data(), "rb");
+
+  if(not file){
+    fastlog(ERROR, "Failed file download! Passing over...");
+    return FILE_NOT_FOUND;
+  } else {
+    fastlog(DEBUG, "Download OK! Renaming temporary file...");
+    std::rename(tmp_path.data(), cache_path.data());
+  }
+
+  fastlog(DEBUG,"Adding to cache file downloaded at %s.", cache_path.data());
+  rucio_download_cache.add_file(cache_path, file);
+
+  return 0;
+}
+
+struct rucio_download_info{
+    std::string ftmp_path, fcache_path, fdid;
+    int freturn_code = 0;
+    uint fattempt = 0;
+    bool fdownloaded = false;
+
+    rucio_download_info(const std::string& cache_path, std::string did) :
+      fcache_path(cache_path),
+      ftmp_path(cache_path+".download"),
+      fdid(std::move(did)){}
+
+    std::string print(){
+      if(fdownloaded){
+        return "Did " + fdid + " downloaded at " + fcache_path;
+      } else {
+        return "Did " + fdid + " download FAILED!";
+      }
+    }
+};
+
+rucio_download_info* rucio_download_wrapper(rucio_download_info& info){
+  if (info.fattempt <= MAX_ATTEMPTS) {
+    info.fattempt++;
+    info.freturn_code = rucio_download_wrapper(info.ftmp_path, info.fcache_path, info.fdid);
+    info.fdownloaded = (info.freturn_code != FILE_NOT_FOUND);
+  } else {
+    info.freturn_code = TOO_MANY_ATTEMPTS;
+    info.fdownloaded = false;
+  }
+  return &info;
+}
+
+#endif //RUCIO_FUSE_POSIX_RUCIO_DOWNLOAD_H

--- a/include/rucio-download.h
+++ b/include/rucio-download.h
@@ -19,6 +19,14 @@ int rucio_download_wrapper(const std::string& did, const std::string& scope){
   //TODO: using rucio download directly, prevents from being able to connect to multiple rucio servers at once
 
   auto cache_path = rucio_cache_path + "/" + scope;
+  auto file_path = cache_path + "/" + did;
+  FILE* file = fopen(file_path.data(), "rb");
+
+  if (file){
+    fclose(file);
+    fastlog(INFO,"File %s already there!",file_path.data());
+    return 0;
+  }
 
   fastlog(DEBUG,"Downloading at %s...",cache_path.data());
 
@@ -26,8 +34,7 @@ int rucio_download_wrapper(const std::string& did, const std::string& scope){
   system(command.data());
 
   fastlog(DEBUG,"Checking downloaded file...");
-  auto file_path = cache_path + "/" + did;
-  FILE* file = fopen(file_path.data(), "rb");
+  file = fopen(file_path.data(), "rb");
 
   if(not file){
     fastlog(ERROR, "Failed file download! Passing over...");

--- a/include/rucio-download.h
+++ b/include/rucio-download.h
@@ -16,7 +16,8 @@ using namespace fastlog;
 
 int rucio_download_wrapper(const std::string& tmp_path, const std::string& cache_path, const std::string& did){
   //TODO: using rucio download directly, prevents from being able to connect to multiple rucio servers at once
-
+  fastlog(DEBUG,"Downloading at %s...",tmp_path.data());
+  
   std::string command = "rucio --verbose download --dir " + tmp_path + " " + did;
   system(command.data());
 

--- a/submodules/CMakeLists.txt
+++ b/submodules/CMakeLists.txt
@@ -11,3 +11,8 @@ target_include_directories(nlohmann_json INTERFACE nlohmann_json/single_include/
 
 add_library(fastlog INTERFACE)
 target_include_directories(fastlog INTERFACE fastlog)
+
+include_directories(warpdrive/include warpdrive/include/interfaces)
+
+add_library(warpdrive INTERFACE)
+target_include_directories(warpdrive INTERFACE warpdrive)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(
         test_curl-REST
-        test_curl-REST.cpp
-)
+        test_curl-REST.cpp)
 target_link_libraries(test_curl-REST PUBLIC curl-wrapper)
 
 add_executable(
@@ -15,3 +14,9 @@ add_executable(
         test_REST-API.cpp
 )
 target_link_libraries(test_REST-API PUBLIC rucio-rest-api-wrapper globals)
+
+add_executable(
+        test_rucio_download_info
+        test_rucio_download_info.cpp
+)
+target_link_libraries(test_rucio_download_info PUBLIC rucio-fuse globals)

--- a/tests/test_rucio_download_info.cpp
+++ b/tests/test_rucio_download_info.cpp
@@ -1,0 +1,13 @@
+//
+// Created by Gabriele Gaetano Fronzé on 2020-06-04.
+//
+
+#include "rucio-download.h"
+
+int main(){
+
+  auto info = rucio_download_info("scope:filename");
+  printf("scope: %s - filename: %s\n",info.scopename().data(),info.filename().data());
+
+  return 0;
+}


### PR DESCRIPTION
With this PR, plain support for files download is implemented using the rucio CLI from the C++ code.

Files are downloaded to a separate location wrt the FUSE mountpoint, in order to get persistent files across reboots.

The downloads are handled asynchronously. At first access a file is reported as non existent, but the download process is trigger and after a while the file will be accessible. The downloads to handle are enqueued in a FIFO connected to a thread pool capable of handling the downloads.