### PR TITLE
Introducing support for .cfg config files parsing - Fixes #24 and #25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(rucio-fuse-posix CXX)
 
 set (CMAKE_BUILD_TYPE DEBUG)
 set (CMAKE_CXX_STANDARD 17)
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -pthread")
 set (CMAKE_C_FLAGS "-O0 -ggdb")
 set (CMAKE_C_FLAGS_DEBUG "-O0 -ggdb")
 set (CMAKE_C_FLAGS_RELEASE "-O0 -ggdb")

--- a/README.md
+++ b/README.md
@@ -111,21 +111,18 @@ $ modprobe fuse
 
 ### Setting up Rucio-FUSE connections
 Now that `fusermount` is set up on the machine, we need to set up the Rucio-FUSE connections before proceeding with the mounting process.
-For this, create a file named `settings.json` based on the template found at `settings.json.template` and add the authentication details.
 
-Each portion in the template contains the following keys:
+The Rucio FUSE module will parse the connection parameters from configuration files in the same format as typical `rucio.cfg` files. 
+All the `.cfg` files found in the path pointed by the environment variable `RUCIOFS_SETTINGS_FILES_ROOT` will be parsed looking for the following required fields in the `[client]` section:
+ - `rucio_host`: the server URL
+ - `username`: the server username
+ - `password`: the server password
+ - `account`: the connection account
 
-* `name`: The name for the server you wish to mount.
-This can be anything the user prefers, not necessarily correspond to a fully qualified domain name (FQDN).
-* `url`: URL to connect with the Rucio server. 
-If you're using the development docker for Rucio enter `https://localhost/` here.
-* `account`: Account name registered with Rucio. 
-* `username`: Username you use to sign-in to your Rucio account. 
-* `password`: Password for your Rucio account. 
+At the moment only `userpass` authentication method is supported.
+To add a new server it is enough to import the existing `.cfg` and restart the FUSE module.
 
-Save the file and exit.
-
-**NOTE:** You can add multiple servers to mount on your machine, just add another portion under "servers" with the required details.
+**NOTE:** The configuration files are passed at runtime to the internal routine performing rucio downloads. Do not remove them without restarting the FUSE module!
 
 ### Mounting with Rucio-FUSE mount
 The FUSE mount can be either used as `root` or the current user.

--- a/include/fuse-op.h
+++ b/include/fuse-op.h
@@ -20,6 +20,7 @@ Authors:
 #include <fastlog.h>
 
 #include "constants.h"
+#include "globals.h"
 #include "download-cache.h"
 #include "rucio-download.h"
 #include "download-pipeline.h"
@@ -161,7 +162,7 @@ static int rucio_read(const char *path, char *buffer, size_t size, off_t offset,
     if(not rucio_download_cache.is_cached(cache_path)) {
       fastlog(DEBUG,"File %s @ %s is not cached. Downloading...", did.data(), server_name.data());
 
-      rucio_download_pipeline.append_new_download(rucio_download_info(did));
+      rucio_download_pipeline.append_new_download(rucio_download_info(did, get_server_config(extract_server_name(path))));
 
       return -ENOENT;
     } else {

--- a/include/globals.h
+++ b/include/globals.h
@@ -69,6 +69,8 @@ connection_parameters* get_server_params(std::string server_name);
 
 token_info* get_server_token(std::string server_name);
 
-void parse_settings();
+void parse_settings_json();
+
+void parse_settings_cfg();
 
 #endif //RUCIO_FUSE_CONNNECTION_PARAMETERS_H

--- a/include/globals.h
+++ b/include/globals.h
@@ -41,6 +41,7 @@ struct token_info{
 struct rucio_server{
   connection_parameters rucio_conn_params;
   token_info rucio_token_info;
+  std::string config_file_path;
 
   rucio_server():rucio_conn_params("","","",""), rucio_token_info(){};
 
@@ -66,6 +67,8 @@ extern std::vector<std::string> rucio_server_names;
 bool key_exists(std::string key);
 
 connection_parameters* get_server_params(std::string server_name);
+
+std::string* get_server_config(std::string server_name);
 
 token_info* get_server_token(std::string server_name);
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -64,13 +64,13 @@ extern std::unordered_map<std::string, rucio_server> rucio_server_map;
 extern std::vector<std::string> rucio_server_names;
 
 // Utility functions
-bool key_exists(std::string key);
+bool key_exists(const std::string& key);
 
-connection_parameters* get_server_params(std::string server_name);
+connection_parameters* get_server_params(const std::string& server_name);
 
-std::string* get_server_config(std::string server_name);
+std::string* get_server_config(const std::string& server_name);
 
-token_info* get_server_token(std::string server_name);
+token_info* get_server_token(const std::string& server_name);
 
 void parse_settings_json();
 

--- a/include/rucio-download.h
+++ b/include/rucio-download.h
@@ -15,7 +15,7 @@ using namespace fastlog;
 #define MAX_ATTEMPTS 3
 #define TOO_MANY_ATTEMPTS 314
 
-int rucio_download_wrapper(const std::string& scope, const std::string& name){
+int rucio_download_wrapper(const std::string& server_config_file, const std::string& scope, const std::string& name){
   //TODO: using rucio download directly, prevents from being able to connect to multiple rucio servers at once
 
   auto cache_path = rucio_cache_path + "/" + scope;
@@ -32,7 +32,7 @@ int rucio_download_wrapper(const std::string& scope, const std::string& name){
   fastlog(DEBUG,"Downloading at %s...",cache_path.data());
 
   std::string did = scope + ":" + name;
-  std::string command = "rucio --verbose download --dir " + cache_path + " " + did;
+  std::string command = "rucio --verbose --config " + server_config_file + " download --dir " + cache_path + " " + did;
   system(command.data());
 
   fastlog(DEBUG,"Checking downloaded file...");
@@ -52,14 +52,16 @@ int rucio_download_wrapper(const std::string& scope, const std::string& name){
 }
 
 struct rucio_download_info{
+    std::string* fserver_config;
     std::string fdid;
     std::string::size_type fpos;
     int freturn_code = 0;
     unsigned int fattempt = 0;
     bool fdownloaded = false;
 
-    explicit rucio_download_info(std::string did) :
-      fdid(std::move(did)){
+    explicit rucio_download_info(std::string did, std::string* server_config) :
+      fdid(std::move(did)),
+      fserver_config(server_config){
       fpos = fdid.find_first_of(':');
     }
 
@@ -87,7 +89,7 @@ struct rucio_download_info{
 rucio_download_info* rucio_download_wrapper(rucio_download_info& info){
   if (info.fattempt <= MAX_ATTEMPTS) {
     info.fattempt++;
-    info.freturn_code = rucio_download_wrapper(info.scopename(), info.filename());
+    info.freturn_code = rucio_download_wrapper(*info.fserver_config, info.scopename(), info.filename());
     info.fdownloaded = (info.freturn_code != FILE_NOT_FOUND);
   } else {
     info.freturn_code = TOO_MANY_ATTEMPTS;

--- a/main.cxx
+++ b/main.cxx
@@ -22,7 +22,7 @@ int main( int argc, char *argv[] )
 
   logLevel = INFO;
 
-  parse_settings();
+  parse_settings_cfg();
 
   std::vector<std::string> argvect(argv, argv + argc);
   if(std::find(argvect.begin(),argvect.end(),"-vv") != argvect.end()){

--- a/rucio-settings/test.cfg
+++ b/rucio-settings/test.cfg
@@ -1,0 +1,12 @@
+[client]
+rucio_host = https://localhost:443
+auth_host = https://localhost:443
+auth_type = userpass
+username = ddmlab
+password = secret
+ca_cert = /opt/rucio/etc/rucio_ca.pem
+client_cert = /opt/rucio/etc/ruciouser.pem
+client_key = /opt/rucio/etc/ruciouser.key.pem
+client_x509_proxy = $X509_USER_PROXY
+account = root
+request_retries = 3

--- a/rucio-settings/userpass.cfg.template
+++ b/rucio-settings/userpass.cfg.template
@@ -1,0 +1,9 @@
+[client]
+rucio_host = https://0.0.0.0 or DNS name
+auth_host = https://0.0.0.0 or DNS name
+auth_type = userpass
+username =
+password =
+account =
+ca_cert =
+request_retries = 3

--- a/source/globals.cpp
+++ b/source/globals.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <fastlog.h>
 #include <REST-API.h>
+#include <dirent.h>
 
 std::unordered_map<std::string, rucio_server> rucio_server_map = {};
 std::vector<std::string> rucio_server_names;
@@ -26,7 +27,7 @@ token_info* get_server_token(std::string server_name){
 using json = nlohmann::json;
 using namespace fastlog;
 
-void parse_settings(){
+void parse_settings_json(){
   std::ifstream settings_file;
 
   std::string ruciofs_settings_filename;
@@ -68,5 +69,72 @@ void parse_settings(){
 
     rucio_server_names.emplace_back(srv_name);
     rucio_server_map.emplace(std::make_pair(srv_name,srv));
+  }
+}
+
+void parse_settings_cfg(){
+  std::string ruciofs_settings_root;
+
+  if(getenv("RUCIOFS_SETTINGS_FILES_ROOT") != NULL){
+    ruciofs_settings_root = getenv("RUCIOFS_SETTINGS_FILES_ROOT");
+  } else ruciofs_settings_root = "./rucio-settings";
+
+  fastlog(INFO,"\nSettings files contained at: %s", ruciofs_settings_root.data());
+
+  struct dirent *inode = nullptr;
+  DIR *dp = opendir(ruciofs_settings_root.data());
+
+  size_t i_srv = 0;
+
+  if (dp) {
+    inode = readdir(dp);
+
+    while(inode){
+      std::string file_name = inode->d_name;
+
+      if(file_name.find(".cfg") != std::string::npos) {
+        fastlog(INFO, "Parsing settings file: %s", file_name.data());
+
+        auto srv = rucio_server();
+
+        std::ifstream settings_file;
+        settings_file.open((ruciofs_settings_root+"/"+file_name).data());
+        std::string line;
+        while (getline(settings_file, line)) {
+          if (line.rfind("rucio_host", 0) == 0) {
+            srv.rucio_conn_params.server_url = line.substr(line.find("rucio_host = "));
+          }
+
+          if (line.rfind("username", 0) == 0) {
+            srv.rucio_conn_params.user_name = line.substr(line.find("username = "));
+          }
+
+          if (line.rfind("password", 0) == 0) {
+            srv.rucio_conn_params.password = line.substr(line.find("password = "));
+          }
+
+          if (line.rfind("account", 0) == 0) {
+            srv.rucio_conn_params.account_name = line.substr(line.find("account = "));
+          }
+        }
+
+        fastlog(INFO, "\n"
+                      "\tServer %d -> %s:\n"
+                      "\t\turl = %s\n"
+                      "\t\taccount = %s\n"
+                      "\t\tusername = %s\n"
+                      "\t\tpassword = %s",
+                i_srv++,
+                file_name.data(),
+                srv.rucio_conn_params.server_url.data(),
+                srv.rucio_conn_params.account_name.data(),
+                srv.rucio_conn_params.user_name.data(),
+                srv.rucio_conn_params.password.data());
+
+//        rucio_server_names.emplace_back(srv_name);
+//        rucio_server_map.emplace(std::make_pair(srv_name,srv));
+      }
+      inode = readdir(dp);
+    }
   }
 }

--- a/source/globals.cpp
+++ b/source/globals.cpp
@@ -8,6 +8,7 @@
 #include <fastlog.h>
 #include <REST-API.h>
 #include <dirent.h>
+#include <algorithm>
 
 std::unordered_map<std::string, rucio_server> rucio_server_map = {};
 std::vector<std::string> rucio_server_names;
@@ -72,6 +73,11 @@ void parse_settings_json(){
   }
 }
 
+std::string get_cfg_value(std::string& line){
+  line.erase(std::remove(line.begin(), line.end(), ' '), line.end());
+  return line.substr(line.find("=") + 1);
+}
+
 void parse_settings_cfg(){
   std::string ruciofs_settings_root;
 
@@ -79,7 +85,7 @@ void parse_settings_cfg(){
     ruciofs_settings_root = getenv("RUCIOFS_SETTINGS_FILES_ROOT");
   } else ruciofs_settings_root = "./rucio-settings";
 
-  fastlog(INFO,"\nSettings files contained at: %s", ruciofs_settings_root.data());
+  fastlog(INFO,"Settings files contained at: %s", ruciofs_settings_root.data());
 
   struct dirent *inode = nullptr;
   DIR *dp = opendir(ruciofs_settings_root.data());
@@ -102,24 +108,23 @@ void parse_settings_cfg(){
         std::string line;
         while (getline(settings_file, line)) {
           if (line.rfind("rucio_host", 0) == 0) {
-            srv.rucio_conn_params.server_url = line.substr(line.find("rucio_host = "));
+            srv.rucio_conn_params.server_url = get_cfg_value(line);
           }
 
           if (line.rfind("username", 0) == 0) {
-            srv.rucio_conn_params.user_name = line.substr(line.find("username = "));
+            srv.rucio_conn_params.user_name = get_cfg_value(line);
           }
 
           if (line.rfind("password", 0) == 0) {
-            srv.rucio_conn_params.password = line.substr(line.find("password = "));
+            srv.rucio_conn_params.password = get_cfg_value(line);
           }
 
           if (line.rfind("account", 0) == 0) {
-            srv.rucio_conn_params.account_name = line.substr(line.find("account = "));
+            srv.rucio_conn_params.account_name = get_cfg_value(line);
           }
         }
 
-        fastlog(INFO, "\n"
-                      "\tServer %d -> %s:\n"
+        fastlog(INFO, "\tServer %d -> %s:\n"
                       "\t\turl = %s\n"
                       "\t\taccount = %s\n"
                       "\t\tusername = %s\n"

--- a/source/globals.cpp
+++ b/source/globals.cpp
@@ -21,6 +21,10 @@ connection_parameters* get_server_params(std::string server_name){
   return (key_exists(server_name)) ? rucio_server_map[server_name].get_params() : nullptr;
 }
 
+std::string* get_server_config(std::string server_name){
+  return (key_exists(server_name)) ? &(rucio_server_map[server_name].config_file_path) : nullptr;
+}
+
 token_info* get_server_token(std::string server_name){
   return (key_exists(server_name)) ? rucio_server_map[server_name].get_token() : nullptr;
 }
@@ -102,9 +106,11 @@ void parse_settings_cfg(){
         fastlog(INFO, "Parsing settings file: %s", file_name.data());
 
         auto srv = rucio_server();
+        srv.config_file_path = ruciofs_settings_root+"/"+file_name;
+        auto srv_name = (file_name.substr(0, file_name.find(".cfg"))).data();
 
         std::ifstream settings_file;
-        settings_file.open((ruciofs_settings_root+"/"+file_name).data());
+        settings_file.open(srv.config_file_path.data());
         std::string line;
         while (getline(settings_file, line)) {
           if (line.rfind("rucio_host", 0) == 0) {
@@ -130,14 +136,14 @@ void parse_settings_cfg(){
                       "\t\tusername = %s\n"
                       "\t\tpassword = %s",
                 i_srv++,
-                file_name.data(),
+                srv_name,
                 srv.rucio_conn_params.server_url.data(),
                 srv.rucio_conn_params.account_name.data(),
                 srv.rucio_conn_params.user_name.data(),
                 srv.rucio_conn_params.password.data());
 
-//        rucio_server_names.emplace_back(srv_name);
-//        rucio_server_map.emplace(std::make_pair(srv_name,srv));
+        rucio_server_names.emplace_back(srv_name);
+        rucio_server_map.emplace(std::make_pair(srv_name,srv));
       }
       inode = readdir(dp);
     }

--- a/source/globals.cpp
+++ b/source/globals.cpp
@@ -107,7 +107,7 @@ void parse_settings_cfg(){
 
         auto srv = rucio_server();
         srv.config_file_path = ruciofs_settings_root + "/" + file_name;
-        auto srv_name = (file_name.substr(0, file_name.find(".cfg"))).data();
+        auto srv_name = file_name.substr(0, file_name.find(".cfg"));
 
         std::ifstream settings_file;
         settings_file.open(srv.config_file_path.data());
@@ -136,7 +136,7 @@ void parse_settings_cfg(){
                       "\t\tusername = %s\n"
                       "\t\tpassword = %s",
                 i_srv++,
-                srv_name,
+                srv_name.data(),
                 srv.rucio_conn_params.server_url.data(),
                 srv.rucio_conn_params.account_name.data(),
                 srv.rucio_conn_params.user_name.data(),

--- a/source/globals.cpp
+++ b/source/globals.cpp
@@ -13,19 +13,19 @@
 std::unordered_map<std::string, rucio_server> rucio_server_map = {};
 std::vector<std::string> rucio_server_names;
 
-bool key_exists(std::string key){
+bool key_exists(const std::string& key){
   return rucio_server_map.count(key)>0;
 }
 
-connection_parameters* get_server_params(std::string server_name){
+connection_parameters* get_server_params(const std::string& server_name){
   return (key_exists(server_name)) ? rucio_server_map[server_name].get_params() : nullptr;
 }
 
-std::string* get_server_config(std::string server_name){
+std::string* get_server_config(const std::string& server_name){
   return (key_exists(server_name)) ? &(rucio_server_map[server_name].config_file_path) : nullptr;
 }
 
-token_info* get_server_token(std::string server_name){
+token_info* get_server_token(const std::string& server_name){
   return (key_exists(server_name)) ? rucio_server_map[server_name].get_token() : nullptr;
 }
 
@@ -79,7 +79,7 @@ void parse_settings_json(){
 
 std::string get_cfg_value(std::string& line){
   line.erase(std::remove(line.begin(), line.end(), ' '), line.end());
-  return line.substr(line.find("=") + 1);
+  return line.substr(line.find('=') + 1);
 }
 
 void parse_settings_cfg(){
@@ -106,7 +106,7 @@ void parse_settings_cfg(){
         fastlog(INFO, "Parsing settings file: %s", file_name.data());
 
         auto srv = rucio_server();
-        srv.config_file_path = ruciofs_settings_root+"/"+file_name;
+        srv.config_file_path = ruciofs_settings_root + "/" + file_name;
         auto srv_name = (file_name.substr(0, file_name.find(".cfg"))).data();
 
         std::ifstream settings_file;

--- a/tests/test_REST-API.cpp
+++ b/tests/test_REST-API.cpp
@@ -68,7 +68,7 @@ void test_scope_dids(std::string server_short_name, std::string scope_name){
 }
 
 int main(){
-  parse_settings();
+  parse_settings_json();
   test_server_connection("rucio-server-torino");
   test_server_connection("rucio-server-ligo");
 

--- a/tests/test_rucio_download_info.cpp
+++ b/tests/test_rucio_download_info.cpp
@@ -2,11 +2,12 @@
 // Created by Gabriele Gaetano Fronzé on 2020-06-04.
 //
 
+#include <globals.h>
 #include "rucio-download.h"
 
 int main(){
-
-  auto info = rucio_download_info("scope:filename");
+  parse_settings_cfg();
+  auto info = rucio_download_info("scope:filename", get_server_config("test"));
   printf("scope: %s - filename: %s\n",info.scopename().data(),info.filename().data());
 
   return 0;


### PR DESCRIPTION
Thanks to this PR, connection settings will be parsed from standard `.cfg` files.
The files parsed at startup will also be passed at runtime to the `rucio download` call thanks to `--config` parameter, in order to enable multi server support even using rucio CLI as backend.