### PR TITLE
Avoid cd to non-existent directories - enables Mac compatibility

### DIFF
--- a/include/REST-API.h
+++ b/include/REST-API.h
@@ -37,16 +37,19 @@ const std::vector<std::string>& rucio_list_servers();
 static std::unordered_map<std::string, std::vector<std::string>> scopes_cache;
 std::vector<std::string> rucio_list_scopes(const std::string& short_server_name);
 
-static std::unordered_map<std::string, bool> is_container_cache;
 static std::unordered_map<std::string, std::vector<rucio_did>> dids_cache;
 std::vector<rucio_did> rucio_list_dids(const std::string& scope, const std::string& short_server_name);
-
 static std::unordered_map<std::string, std::vector<rucio_did>> container_dids_cache;
+
 std::vector<rucio_did> rucio_list_container_dids(const std::string& scope, const std::string& container_name, const std::string& short_server_name);
 
 // Returns true if did is container of dataset, false otherwise (for files)
+static std::unordered_map<std::string, bool> is_container_cache;
 bool rucio_is_container(const rucio_did& did);
 bool rucio_is_container(const std::string& path);
+
+static std::unordered_map<std::string, bool> is_file_cache;
+bool rucio_is_file(const std::string& path);
 
 // Metadata access methods
 static std::unordered_map<std::string, size_t> file_size_cache;

--- a/include/REST-API.h
+++ b/include/REST-API.h
@@ -17,9 +17,10 @@
 #define SERVER_NOT_LOADED 1
 #define CANNOT_AUTH 2
 #define TOKEN_ERROR 3
+#define CURL_ERROR 4
 
 // Ping and server validation methods
-bool rucio_ping(const std::string& server_url);
+bool rucio_ping(const std::string& short_server_name);
 
 // Auth and token validation methods
 int rucio_get_auth_token(const std::string& short_server_name);

--- a/include/fuse-op.h
+++ b/include/fuse-op.h
@@ -86,14 +86,17 @@ static int rucio_getattr (const char *path, struct stat *st){
 	return 0;
 }
 
+static int finalize_filler(void *buffer, fuse_fill_dir_t filler){
+  filler(buffer, ".", nullptr, 0 );
+  filler(buffer, "..", nullptr, 0 );
+  return 0;
+}
+
 // This is the method called when using cd
 static int rucio_readdir(const char *path, void *buffer, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi)
 {
   fastlog(DEBUG,"rucio_readdir called");
   fastlog(INFO,"Handling this path: %s", path);
-
-  filler(buffer, ".", nullptr, 0 );
-  filler(buffer, "..", nullptr, 0 );
 
   if (is_hidden(path)) return 0;
 
@@ -105,7 +108,7 @@ static int rucio_readdir(const char *path, void *buffer, fuse_fill_dir_t filler,
     for(auto const& server : servers){
       filler(buffer, server.data(), nullptr, 0 );
     }
-    return 0;
+    return finalize_filler(buffer, filler);
 
 	}	else {
 	  std::string server_short_name = extract_server_name(path);
@@ -118,7 +121,7 @@ static int rucio_readdir(const char *path, void *buffer, fuse_fill_dir_t filler,
       for(auto const& scope : scopes){
         filler(buffer, scope.data(), nullptr, 0 );
       }
-      return 0;
+      return finalize_filler(buffer, filler);
 
 	  } else {
       // If is one of the top level scopes list the dids inside
@@ -129,7 +132,7 @@ static int rucio_readdir(const char *path, void *buffer, fuse_fill_dir_t filler,
         for(auto const& did : dids){
           filler(buffer, did.name.data(), nullptr, 0 );
         }
-        return 0;
+        return finalize_filler(buffer, filler);
 
       // Otherwise, if a container (or a dataset), list its dids
       } else if (rucio_is_container(path)) {
@@ -145,7 +148,7 @@ static int rucio_readdir(const char *path, void *buffer, fuse_fill_dir_t filler,
         for(auto const& did : container_dids){
           filler(buffer, did.name.data(), nullptr, 0 );
         }
-        return 0;
+        return finalize_filler(buffer, filler);
       }
     }
 	}

--- a/include/fuse-op.h
+++ b/include/fuse-op.h
@@ -30,17 +30,17 @@ using namespace fastlog;
 
 // This is the method which renders the posix namespace and set the file/dir permissions
 static int rucio_getattr (const char *path, struct stat *st){
+  if (is_hidden(path)) return 0;
+
+  if (is_mac_specific(path)) return 0;
+
   fastlog(DEBUG,"rucio_getattr called");
-  fastlog(INFO,"Handling this path: %s", path);
+  fastlog(DEBUG,"Handling this path: %s", path);
 
   st->st_uid = getuid();
 	st->st_gid = getgid();
 	st->st_atime = time( nullptr );
 	st->st_mtime = time( nullptr );
-
-  if (is_hidden(path)) return 0;
-
-  if (is_mac_specific(path)) return 0;
 
 	// If it is the root path list the connected servers
 	if ( is_root_path(path) ) {

--- a/include/globals.h
+++ b/include/globals.h
@@ -34,16 +34,19 @@ struct connection_parameters{
   std::string user_name;
   std::string password;
   auth_mode rucio_auth_mode;
+  std::string ca_path;
 
   connection_parameters(std::string server_url,
                         std::string account_name,
                         std::string user_name,
                         std::string password,
+                        std::string ca_path,
                         const std::string& auth_method_line = "userpass"):
                         server_url(std::move(server_url)),
                         account_name(std::move(account_name)),
                         user_name(std::move(user_name)),
                         password(std::move(password)),
+                        ca_path(std::move(ca_path)),
                         rucio_auth_mode(get_auth_mode(auth_method_line)){}
 };
 
@@ -62,17 +65,19 @@ struct rucio_server{
   token_info rucio_token_info;
   std::string config_file_path;
 
-  rucio_server():rucio_conn_params("","","",""), rucio_token_info(){};
+  rucio_server():rucio_conn_params("","","","",""), rucio_token_info(){};
 
   rucio_server(std::string server_url,
                std::string account_name,
                std::string user_name,
                std::string password,
-               std::string auth_mode):
+               std::string ca_path,
+               const std::string& auth_mode):
                rucio_conn_params(std::move(server_url),
                                  std::move(account_name),
                                  std::move(user_name),
                                  std::move(password),
+                                 std::move(ca_path),
                                  auth_mode),
                rucio_token_info(){}
 
@@ -86,9 +91,9 @@ extern std::vector<std::string> rucio_server_names;
 
 // Utility functions
 bool server_exists(const std::string &key);
-connection_parameters* get_server_params(const std::string& server_name);
+connection_parameters*  get_server_params(const std::string& server_name);
+std::string*  get_server_config(const std::string& server_name);
 curlx509Bundle* get_server_SSL_bundle(const std::string& server_name);
-std::string* get_server_config(const std::string& server_name);
 token_info* get_server_token(const std::string& server_name);
 
 // Startup functions

--- a/include/utils.h
+++ b/include/utils.h
@@ -86,6 +86,10 @@ struct rucio_did{
   std::string name;
   std::string parent;
   int level;
+
+  bool operator==(const rucio_did& check){
+    return this->scope == check.scope && this->name == check.name;
+  }
 };
 
 // Translators from string-like rucio did descriptor to rucio_did structures

--- a/source/REST-API.cpp
+++ b/source/REST-API.cpp
@@ -70,7 +70,7 @@ int rucio_get_auth_token_userpass(const std::string& short_server_name){
 
   auto curl_res = GET(conn_params->server_url+"/auth/userpass", conn_params->ca_path, headers, true);
   if(curl_res.res != CURLE_OK){
-    fastlog(ERROR, "Curl error. Abort.");
+    fastlog(ERROR, "Token: Curl error. Abort.");
     return CURL_ERROR;
   }
 
@@ -133,7 +133,7 @@ int rucio_get_auth_token_x509(const std::string& short_server_name){
 
   auto curl_res = GET_x509(conn_params->server_url + "/auth/x509", *bundle, headers, true);
   if(curl_res.res != CURLE_OK){
-    fastlog(ERROR, "Curl error. Abort.");
+    fastlog(ERROR, "Token x509: Curl error. Abort.");
     return CURL_ERROR;
   }
 
@@ -214,7 +214,7 @@ std::vector<std::string> rucio_list_scopes(const std::string& short_server_name)
 
     auto curl_res = GET(conn_params->server_url + "/scopes/", conn_params->ca_path, headers);
     if(curl_res.res != CURLE_OK){
-      fastlog(ERROR, "Curl error. Abort.");
+      fastlog(ERROR, "Scopes: Curl error. Abort.");
       return {};
     }
 
@@ -269,7 +269,7 @@ std::vector<rucio_did> rucio_list_dids(const std::string& scope, const std::stri
 
     auto curl_res = GET(conn_params->server_url + "/dids/" + scope + "/", conn_params->ca_path, headers);
     if(curl_res.res != CURLE_OK){
-      fastlog(ERROR, "Curl error. Abort.");
+      fastlog(ERROR, "Dids: Curl error. Abort.");
       return {};
     }
 
@@ -312,7 +312,7 @@ std::vector<rucio_did> rucio_list_container_dids(const std::string& scope, const
             conn_params->ca_path,
             headers);
     if(curl_res.res != CURLE_OK){
-      fastlog(ERROR, "Curl error. Abort.");
+      fastlog(ERROR, "Container: Curl error. Abort.");
       return {};
     }
 
@@ -362,14 +362,15 @@ bool rucio_is_container(const std::string& path){
                         conn_params->ca_path,
                         headers);
     if(curl_res.res != CURLE_OK){
-      fastlog(ERROR, "Curl error. Abort.");
+      fastlog(ERROR, "IsCont: Curl error. Abort.");
       return false;
     }
 
 
     curl_slist_free_all(headers);
 
-    is_container_cache[path] = curl_res.payload.front().find(R"("type": "FILE",)") == std::string::npos;
+    is_container_cache[path] = curl_res.payload.front().find(R"("CONTAINER",)") != std::string::npos;
+    is_container_cache[path] |= curl_res.payload.front().find(R"("DATASET",)") != std::string::npos;
     return is_container_cache[path];
   } else {
     fastlog(DEBUG,"USING CACHE");
@@ -398,14 +399,14 @@ bool rucio_is_file(const std::string& path){
                         conn_params->ca_path,
                         headers);
     if(curl_res.res != CURLE_OK){
-      fastlog(ERROR, "Curl error. Abort.");
+      fastlog(ERROR, "IsFile: Curl error. Abort. %s", (conn_params->server_url + "/dids/" + scope + "/" + name).data());
       return false;
     }
 
 
     curl_slist_free_all(headers);
 
-    is_file_cache[path] = curl_res.payload.front().find(R"("type": "FILE",)") != std::string::npos;
+    is_file_cache[path] = curl_res.payload.front().find(R"("FILE",)") != std::string::npos;
     return is_file_cache[path];
   } else {
     fastlog(DEBUG,"USING CACHE");
@@ -438,7 +439,7 @@ size_t rucio_get_size(const std::string& path){
                       conn_params->ca_path,
                       headers);
   if(curl_res.res != CURLE_OK){
-    fastlog(ERROR, "Curl error. Abort.");
+    fastlog(ERROR, "Size: Curl error. Abort.");
     return 0;
   }
 
@@ -476,7 +477,7 @@ std::vector<std::string> rucio_get_replicas_metalinks(const std::string& path){
                       conn_params->ca_path,
                       headers);
   if(curl_res.res != CURLE_OK){
-    fastlog(ERROR, "Curl error. Abort.");
+    fastlog(ERROR, "Meta: Curl error. Abort.");
     return {};
   }
 

--- a/source/REST-API.cpp
+++ b/source/REST-API.cpp
@@ -15,15 +15,17 @@ Authors:
 
 using namespace fastlog;
 
-bool rucio_ping(const std::string& server_url){
-  auto curl_res = GET(server_url+"/ping", "");
+bool rucio_ping(const std::string& short_server_name){
+  auto conn_params = get_server_params(short_server_name);
+
+  auto curl_res = GET(conn_params->server_url+"/ping", conn_params->ca_path);
   return curl_res.res == CURLE_OK;
 }
 
 bool rucio_validate_server(const std::string& short_server_name){
   auto conn_params = get_server_params(short_server_name);
 
-  if(not rucio_ping(conn_params->server_url)){
+  if(not rucio_ping(short_server_name)){
     fastlog(ERROR, "Server %s unreachable via network.", conn_params->server_url.data());
     return false;
   }
@@ -66,7 +68,11 @@ int rucio_get_auth_token_userpass(const std::string& short_server_name){
   headers= curl_slist_append(headers, xRucioUsername.c_str());
   headers= curl_slist_append(headers, xRucioPwd.c_str());
 
-  auto curl_res = GET(conn_params->server_url+"/auth/userpass", *get_server_config(short_server_name), headers, true);
+  auto curl_res = GET(conn_params->server_url+"/auth/userpass", conn_params->ca_path, headers, true);
+  if(curl_res.res != CURLE_OK){
+    fastlog(ERROR, "Curl error. Abort.");
+    return CURL_ERROR;
+  }
 
   curl_slist_free_all(headers);
 
@@ -126,6 +132,11 @@ int rucio_get_auth_token_x509(const std::string& short_server_name){
   headers = curl_slist_append(headers, xRucioAccount.c_str());
 
   auto curl_res = GET_x509(conn_params->server_url + "/auth/x509", *bundle, headers, true);
+  if(curl_res.res != CURLE_OK){
+    fastlog(ERROR, "Curl error. Abort.");
+    return CURL_ERROR;
+  }
+
 
   curl_slist_free_all(headers);
 
@@ -201,7 +212,12 @@ std::vector<std::string> rucio_list_scopes(const std::string& short_server_name)
 
     headers = curl_slist_append(headers, xRucioToken.c_str());
 
-    auto curl_res = GET(conn_params->server_url + "/scopes/", *get_server_config(short_server_name), headers);
+    auto curl_res = GET(conn_params->server_url + "/scopes/", conn_params->ca_path, headers);
+    if(curl_res.res != CURLE_OK){
+      fastlog(ERROR, "Curl error. Abort.");
+      return {};
+    }
+
 
     curl_slist_free_all(headers);
 
@@ -240,6 +256,7 @@ curl_slist* get_auth_headers(const std::string& short_server_name){
 }
 
 std::vector<rucio_did> rucio_list_dids(const std::string& scope, const std::string& short_server_name){
+  auto conn_params = get_server_params(short_server_name);
   auto key = short_server_name+scope;
   auto found = dids_cache.find(key);
   if(found == dids_cache.end()) {
@@ -250,7 +267,12 @@ std::vector<rucio_did> rucio_list_dids(const std::string& scope, const std::stri
       return {};
     }
 
-    auto curl_res = GET(get_server_params(short_server_name)->server_url + "/dids/" + scope + "/", *get_server_config(short_server_name), headers);
+    auto curl_res = GET(conn_params->server_url + "/dids/" + scope + "/", conn_params->ca_path, headers);
+    if(curl_res.res != CURLE_OK){
+      fastlog(ERROR, "Curl error. Abort.");
+      return {};
+    }
+
 
     curl_slist_free_all(headers);
 
@@ -273,6 +295,7 @@ std::vector<rucio_did> rucio_list_dids(const std::string& scope, const std::stri
 }
 
 std::vector<rucio_did> rucio_list_container_dids(const std::string& scope, const std::string& container_name, const std::string& short_server_name){
+  auto conn_params = get_server_params(short_server_name);
   auto key = short_server_name+scope+container_name;
   auto found = container_dids_cache.find(key);
   if(found == container_dids_cache.end()) {
@@ -285,9 +308,14 @@ std::vector<rucio_did> rucio_list_container_dids(const std::string& scope, const
     }
 
     auto curl_res = GET(
-            get_server_params(short_server_name)->server_url + "/dids/" + scope + "/" + container_name + "/dids",
-            *get_server_config(short_server_name),
+            conn_params->server_url + "/dids/" + scope + "/" + container_name + "/dids",
+            conn_params->ca_path,
             headers);
+    if(curl_res.res != CURLE_OK){
+      fastlog(ERROR, "Curl error. Abort.");
+      return {};
+    }
+
 
     curl_slist_free_all(headers);
 
@@ -317,6 +345,7 @@ bool rucio_is_container(const rucio_did& did){
 
 bool rucio_is_container(const std::string& path){
   auto short_server_name = extract_server_name(path);
+  auto conn_params = get_server_params(short_server_name);
   auto scope = extract_scope(path);
   auto name = extract_name(path);
   auto found = is_container_cache.find(short_server_name+scope+name);
@@ -329,9 +358,14 @@ bool rucio_is_container(const std::string& path){
       return {};
     }
 
-    auto curl_res = GET(get_server_params(short_server_name)->server_url + "/dids/" + scope + "/" + name,
-                        *get_server_config(short_server_name),
+    auto curl_res = GET(conn_params->server_url + "/dids/" + scope + "/" + name,
+                        conn_params->ca_path,
                         headers);
+    if(curl_res.res != CURLE_OK){
+      fastlog(ERROR, "Curl error. Abort.");
+      return false;
+    }
+
 
     curl_slist_free_all(headers);
 
@@ -353,6 +387,7 @@ size_t rucio_get_size(const std::string& path){
   }
 
   auto short_server_name = extract_server_name(path);
+  auto conn_params = get_server_params(short_server_name);
   auto scope = extract_scope(path);
   auto name = extract_name(path);
 
@@ -363,9 +398,15 @@ size_t rucio_get_size(const std::string& path){
     return {};
   }
 
-  auto curl_res = GET(get_server_params(short_server_name)->server_url + "/dids/" + scope + "/" + name,
-                      *get_server_config(short_server_name),
+  auto curl_res = GET(conn_params->server_url + "/dids/" + scope + "/" + name,
+                      conn_params->ca_path,
                       headers);
+  if(curl_res.res != CURLE_OK){
+    fastlog(ERROR, "Curl error. Abort.");
+    return 0;
+  }
+
+
   for(auto const& payload : curl_res.payload){
     auto found = payload.find(rucio_bytes_metadata);
     if (found != std::string::npos) {
@@ -383,6 +424,7 @@ size_t rucio_get_size(const std::string& path){
 
 std::vector<std::string> rucio_get_replicas_metalinks(const std::string& path){
   auto short_server_name = extract_server_name(path);
+  auto conn_params = get_server_params(short_server_name);
   auto scope = extract_scope(path);
   auto name = extract_name(path);
 
@@ -394,9 +436,14 @@ std::vector<std::string> rucio_get_replicas_metalinks(const std::string& path){
   }
   headers= curl_slist_append(headers, "HTTP_ACCEPT: metalink4+xml");
 
-  auto curl_res = GET(get_server_params(short_server_name)->server_url + "/replicas/" + scope + "/" + name,
-                      *get_server_config(short_server_name),
+  auto curl_res = GET(conn_params->server_url + "/replicas/" + scope + "/" + name,
+                      conn_params->ca_path,
                       headers);
+  if(curl_res.res != CURLE_OK){
+    fastlog(ERROR, "Curl error. Abort.");
+    return {};
+  }
+
 
   std::string merged_response;
 

--- a/source/curl-REST.cpp
+++ b/source/curl-REST.cpp
@@ -25,7 +25,7 @@ curlRet GET(const std::string& url, const std::string& ca_path, const struct cur
   curlRet ret;
   auto static_curl = curlSingleton::curlWrap();
 
-  fastlog(DEBUG,"GET %s",url.data());
+  fastlog(INFO,"GET %s",url.data());
   fastlog(DEBUG,"CA path %s",ca_path.data());
 
   curl_easy_setopt(static_curl(), CURLOPT_URL, url.c_str());
@@ -57,7 +57,7 @@ curlRet GET(const std::string& url, const std::string& ca_path, const struct cur
   // Check return code to detect issues
   if(ret.res != CURLE_OK)
   {
-      fastlog(ERROR, "curl_easy_perform() failed: %s", curl_easy_strerror(ret.res));
+    fastlog(ERROR, "curl_easy_perform() failed: %s url=", curl_easy_strerror(ret.res), url.c_str());
   }
 
   // Reset headers

--- a/source/curl-REST.cpp
+++ b/source/curl-REST.cpp
@@ -10,6 +10,7 @@
 
 #define CURLOPT_FALSE 0L
 #define CURLOPT_TRUE 1L
+#define CURLOPT_SUPERTRUE 2L
 
 using namespace fastlog;
 
@@ -25,10 +26,11 @@ curlRet GET(const std::string& url, const std::string& ca_path, const struct cur
   auto static_curl = curlSingleton::curlWrap();
 
   fastlog(DEBUG,"GET %s",url.data());
+  fastlog(DEBUG,"CA path %s",ca_path.data());
 
   curl_easy_setopt(static_curl(), CURLOPT_URL, url.c_str());
-  curl_easy_setopt(static_curl(), CURLOPT_SSL_VERIFYPEER, CURLOPT_FALSE); //only for https
-  curl_easy_setopt(static_curl(), CURLOPT_SSL_VERIFYHOST, CURLOPT_TRUE); //only for https
+  curl_easy_setopt(static_curl(), CURLOPT_SSL_VERIFYPEER, CURLOPT_TRUE); //only for https
+  curl_easy_setopt(static_curl(), CURLOPT_SSL_VERIFYHOST, CURLOPT_SUPERTRUE); //only for https
   curl_easy_setopt(static_curl(), CURLOPT_CAINFO, ca_path.data());
   curl_easy_setopt(static_curl(), CURLOPT_CAPATH, ca_path.data());
 //  curl_easy_setopt(static_curl(), CURLOPT_SSL_VERIFYHOST, ((url.find("https") != std::string::npos)?CURLOPT_TRUE:CURLOPT_FALSE)); //only for https
@@ -76,6 +78,7 @@ curlRet GET_x509(const std::string& url, curlx509Bundle& bundle, const struct cu
   auto static_curl = curlSingleton::curlWrap();
 
   fastlog(DEBUG,"GET x509 %s",url.data());
+  fastlog(DEBUG,"CA path %s",bundle.pCACertFile.data());
 
   curl_easy_setopt(static_curl(), CURLOPT_URL, url.c_str());
 
@@ -98,7 +101,8 @@ curlRet GET_x509(const std::string& url, curlx509Bundle& bundle, const struct cu
   curl_easy_setopt(static_curl(), CURLOPT_CAINFO, bundle.pCACertFile.data());
   curl_easy_setopt(static_curl(), CURLOPT_CAPATH, bundle.pCACertFile.data());
 
-  curl_easy_setopt(static_curl(), CURLOPT_SSL_VERIFYPEER, CURLOPT_FALSE); //only for https
+  curl_easy_setopt(static_curl(), CURLOPT_SSL_VERIFYPEER, CURLOPT_TRUE); //only for https
+  curl_easy_setopt(static_curl(), CURLOPT_SSL_VERIFYHOST, CURLOPT_SUPERTRUE); //only for https
 
   curl_easy_setopt(static_curl(), CURLOPT_WRITEFUNCTION, curl_append_string_to_vect_callback);
   curl_easy_setopt(static_curl(), CURLOPT_WRITEDATA, &ret.payload);

--- a/source/globals.cpp
+++ b/source/globals.cpp
@@ -43,6 +43,10 @@ connection_parameters* get_server_params(const std::string& server_name){
   return (server_exists(server_name)) ? rucio_server_map[server_name].get_params() : nullptr;
 }
 
+std::string*  get_server_config(const std::string& server_name){
+  return (server_exists(server_name)) ? &rucio_server_map[server_name].config_file_path : nullptr;
+}
+
 // Useful method to extract values from rucio.cfg-like files
 std::string get_cfg_value(std::string& line){
   line.erase(std::remove(line.begin(), line.end(), ' '), line.end());
@@ -75,11 +79,6 @@ curlx509Bundle* get_server_SSL_bundle(const std::string& server_name){
   settings_file.close();
 
   return bundle;
-}
-
-// Returns path to server config file as string ptr
-std::string* get_server_config(const std::string& server_name){
-  return (server_exists(server_name)) ? &(rucio_server_map[server_name].config_file_path) : nullptr;
 }
 
 // Returns token_info if found
@@ -153,6 +152,8 @@ void parse_settings_cfg(){
           if (!ca_file) {
             fastlog(ERROR, "CA file not found at %s. Server will be skipped.", ca_file_path.data());
             continue;
+          } else {
+            srv.rucio_conn_params.ca_path = ca_file_path;
           }
 
           fastlog(INFO, "\tServer %d -> %s:\n"
@@ -160,16 +161,20 @@ void parse_settings_cfg(){
                         "\t\taccount = %s\n"
                         "\t\tusername = %s\n"
                         "\t\tpassword = %s\n"
-                        "\t\tauth_type = %s\n",
+                        "\t\tauth_type = %s\n"
+                        "\t\tca_path = %s\n",
                   i_srv++,
                   srv_name.data(),
                   srv.rucio_conn_params.server_url.data(),
                   srv.rucio_conn_params.account_name.data(),
                   srv.rucio_conn_params.user_name.data(),
                   srv.rucio_conn_params.password.data(),
-                  get_auth_name(srv.rucio_conn_params.rucio_auth_mode).data());
+                  get_auth_name(srv.rucio_conn_params.rucio_auth_mode).data(),
+                  srv.rucio_conn_params.ca_path.data());
 
           rucio_server_map.emplace(std::make_pair(srv_name, srv));
+
+          fastlog(INFO, "Validating server %s.", srv_name.data());
 
           if (not rucio_validate_server(srv_name)) {
             fastlog(ERROR, "Unable to validate server %s. Dropping.", srv_name.data());


### PR DESCRIPTION
The issue was caused by a wrong handling of the filler object when performing cd.
Adding by default `.` and `..` to the folder filler caused inexistent paths to be handled as existent.