### PR TITLE
Fixing python lists parsing

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -60,7 +60,7 @@ bool is_mac_specific(const std::string &path);
 // Method to parse a string-printed python list into a vector with correct type content
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template<class T>
-void tokenize_python_list(std::string list, std::vector<T>& target, char separator = ',', std::array<char,2> unwanted_chars = {'"', ' '}){
+void tokenize_python_list(std::string list, std::vector<T>& target, char separator = ',', std::array<char,3> unwanted_chars = {'"', ' ', ']'}){
   std::string list_copy = list;
   std::string element;
 


### PR DESCRIPTION
Some updates in the base code caused the lists parsing to be broken.
This little fix solves all issues and gets rucio-fs back to work.